### PR TITLE
Ignore case when detecting UTF-8 locales.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,7 +22,8 @@ pub fn on(stream: Stream) -> bool {
         let ctype = std::env::var("LC_ALL")
             .or_else(|_| std::env::var("LC_CTYPE"))
             .or_else(|_| std::env::var("LANG"))
-            .unwrap_or_else(|_| "".into());
+            .unwrap_or_else(|_| "".into())
+            .to_uppercase();
         ctype.ends_with("UTF8") || ctype.ends_with("UTF-8")
     }
 }


### PR DESCRIPTION
I noticed on an Arch Linux installation that `miette` always used an ASCII character set when printing reports despite the system and terminal emulator supporting Unicode. Upon further inspection, it looks like `supports-unicode` looks for a case sensitive `UTF8` or `UTF-8` suffix in locale environment variables, but casing of these values differs between Unix and Linux distributions.

This change performs a case-insensitive comparison by converting the text to uppercase first. Please take a look! Thanks!