### PR TITLE
Switch from `atty` to `is-terminal`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # `supports-unicode` Release Changelog
 
+<a name="2.0.0"></a>
+## 2.0.0 (????)
+
+### Breaking Changes
+
+* `supports-unicode` now uses `is-terminal` instead of `atty`. This changes the external API.
+
 <a name="1.0.2"></a>
 ## 1.0.2 (2021-09-27)
 
@@ -20,4 +27,3 @@
 ### Features
 
 * **api:** initial commit ([0b57e63a](https://github.com/zkat/supports-unicode/commit/0b57e63a443d4aab57ecf24868394e0d06984465))
-

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,5 @@
 # `supports-unicode` Release Changelog
 
-<a name="2.0.0"></a>
-## 2.0.0 (????)
-
-### Breaking Changes
-
-* `supports-unicode` now uses `is-terminal` instead of `atty`. This changes the external API.
-
 <a name="1.0.2"></a>
 ## 1.0.2 (2021-09-27)
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,4 +11,4 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-is-terminal = "0.4.1"
+is-terminal = "0.4.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,4 +11,4 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-atty = "0.2.14"
+is-terminal = "0.4.1"

--- a/README.md
+++ b/README.md
@@ -9,7 +9,9 @@ This crate is a Rust port mashing together
 ## Example
 
 ```rust
-if supports_unicode::on(&std::io::stdout()) {
+use supports_unicode::Stream;
+
+if supports_unicode::on(Stream::Stdout) {
     println!("stdout supports unicode output");
 } else {
     println!("no unicode, please");

--- a/README.md
+++ b/README.md
@@ -9,9 +9,7 @@ This crate is a Rust port mashing together
 ## Example
 
 ```rust
-use supports_unicode::Stream;
-
-if supports_unicode::on(Stream::Stdout) {
+if supports_unicode::on(&std::io::stdout()) {
     println!("stdout supports unicode output");
 } else {
     println!("no unicode, please");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,22 @@
 #![doc = include_str!("../README.md")]
 
-pub fn on(stream: &dyn is_terminal::IsTerminal) -> bool {
-    if !stream.is_terminal() {
+/// possible stream sources
+#[derive(Clone, Copy, Debug)]
+pub enum Stream {
+    Stdout,
+    Stderr,
+}
+
+fn is_a_tty(stream: Stream) -> bool {
+    use is_terminal::*;
+    match stream {
+        Stream::Stdout => std::io::stdout().is_terminal(),
+        Stream::Stderr => std::io::stderr().is_terminal(),
+    }
+}
+
+pub fn on(stream: Stream) -> bool {
+    if !is_a_tty(stream) {
         // If we're just piping out, it's fine to spit out unicode! :)
         true
     } else if std::env::consts::OS == "windows" {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,9 +1,7 @@
 #![doc = include_str!("../README.md")]
 
-pub use atty::Stream;
-
-pub fn on(stream: Stream) -> bool {
-    if !atty::is(stream) {
+pub fn on(stream: &dyn is_terminal::IsTerminal) -> bool {
+    if !stream.is_terminal() {
         // If we're just piping out, it's fine to spit out unicode! :)
         true
     } else if std::env::consts::OS == "windows" {


### PR DESCRIPTION
This is a simple switch but is a breaking change to the external API.