### PR TITLE
Switch to `std::io::IsTerminal`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,4 @@ documentation = "https://docs.rs/supports-unicode"
 license = "Apache-2.0"
 readme = "README.md"
 edition = "2018"
-
-[dependencies]
-is-terminal = "0.4.0"
+rust-version = "1.70.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,7 @@ pub enum Stream {
 }
 
 fn is_a_tty(stream: Stream) -> bool {
-    use is_terminal::*;
+    use std::io::IsTerminal;
     match stream {
         Stream::Stdout => std::io::stdout().is_terminal(),
         Stream::Stderr => std::io::stderr().is_terminal(),


### PR DESCRIPTION
This drops the `is-terminal` dependency, but it also raises the MSRV.