### PR TITLE
docs: fix supports_unicode::on documentation for TTY behavior

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,7 +15,7 @@ fn is_a_tty(stream: Stream) -> bool {
     }
 }
 
-/// Returns true if `stream` is a TTY or the current terminal
+/// Returns true if `stream` is piped or if the current terminal
 /// [supports_unicode].
 pub fn on(stream: Stream) -> bool {
     if !is_a_tty(stream) {


### PR DESCRIPTION
The docs were inverted from what the function actually does. It always returns true if the output is *not* a TTY.